### PR TITLE
Reduce CFrame size by half

### DIFF
--- a/Decode.lua
+++ b/Decode.lua
@@ -271,23 +271,12 @@ local functions = {
 	end,
 	
 	function(input: buffer, offset: number) -- UDim2
-		local comp = buru8(input, offset)
-		local func,mult
-		if comp == 1 then
-			func = burf32
-			mult = 1
-		else
-			func = burf64
-			mult = 2
-		end
-		offset+=1
-		
-		local Xscale = func(input, offset)
-		local Xoffset = func(input, offset + 4 * mult)
-		local Yscale = func(input, offset + 8 * mult)
-		local Yoffset = func(input, offset + 12 * mult)
+		local Xscale = burf32(input, offset)
+		local Xoffset = burf32(input, offset + 4)
+		local Yscale = burf32(input, offset + 8)
+		local Yoffset = burf32(input, offset + 12)
 
-		offset += 16 * mult
+		offset += 16
 		return UD2new(Xscale, Xoffset, Yscale, Yoffset), offset
 	end,
 }

--- a/Encode.lua
+++ b/Encode.lua
@@ -295,7 +295,12 @@ functions = {
 	end,
 	
 	function(v) -- UDim2
-		return OutlineMoment(v)
+		local dat = v.Data
+		local buf = bucr(#dat*4)
+		for i,d in pairs(dat) do
+			buwf32(buf,(i-1)*4,d)
+		end
+		return buf
 	end,
 }
 

--- a/NetShrink.lua
+++ b/NetShrink.lua
@@ -559,13 +559,11 @@ end
 
 --[[
 Create a NetShrink data type for a CFrame.
-Size: 48 bytes as float, 96 bytes as double.
+Size: 24 bytes
 ]]
-module.CFrame = function(input: CFrame, float: boolean)
-	if not float then float = false end
+module.CFrame = function(input: CFrame)
 	return {
 		DataType = 9,
-		comp = float,
 		Data = {input:GetComponents()}
 	}
 end
@@ -856,5 +854,6 @@ module.Encode = function(...)
 end
 
 return module
+
 
 

--- a/NetShrink.lua
+++ b/NetShrink.lua
@@ -2,7 +2,7 @@ local module = {}
 
 --[[
 
-NetShrink v1.5.1
+NetShrink v1.5.2
 Compressing anything possible into binary data!
 
 Developed by EmK530
@@ -854,6 +854,7 @@ module.Encode = function(...)
 end
 
 return module
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Compresses every Color3 channel as a UInt8 instead of a floating point number, r
 **Default value: true**
 
 #### UseEulerCFrames
-Compresses CFrames with only XYZ coordinates and euler angles, cutting data size in half.<br>
+Compresses CFrames with only XYZ coordinates and euler angles.<br>
+<b>Do not enable, compressed size is worse on v1.5.2, improvements coming soon.</b><br>
 **Default value: false**
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -208,10 +208,9 @@ Example: `NetShrink.Vector3int16(Vector3int16.new(32767,-32768,16384))`
 <hr>
 
 ### CFrame
-Stores a CFrame with an option to use single-precision to reduce size by half.<br>
-Sizes: `Single-precision: 48 bytes`, `Double-precision: 96 bytes.`<br>
-Arguments: `input: CFrame`, `float: boolean`, setting `float` to true will encode the CFrame as single-precision, sacrificing precision for size.<br>
-Example: `NetShrink.CFrame(workspace.SpawnLocation.CFrame,true)`, this encodes as single-precision.
+Stores a CFrame into 24 bytes.<br>
+Arguments: `input: CFrame`<br>
+Example: `NetShrink.CFrame(workspace.SpawnLocation.CFrame)`
 <hr>
 
 ### CFrameEuler


### PR DESCRIPTION
did some tests beforehand to make sure it works. the error between expected and result should be lower than robloxs one.
```

11:18:44.531  CFRAME 1  -  Edit
  11:18:44.531  EXPECTED: -1, 2, -3, -0.87415731, -0.135859311, -0.466252416, -7.4505806e-09, 0.960072577, -0.27975145, 0.48564294, -0.244546771, -0.839254379  -  Edit
  11:18:44.531  RESULT -1, 2, -3, -0.874172211, -0.1358684, -0.466261774, 0, 0.960081816, -0.279763162, 0.485660434, -0.24456118, -0.83927685  -  Edit
  11:18:44.531  CFRAME 2  -  Edit
  11:18:44.532  EXPECTED: 1, 5, 3, 0.948683321, -0.122859038, -0.29138577, 7.45058149e-09, 0.921442628, -0.38851434, 0.316227794, 0.368577063, 0.87415725  -  Edit
  11:18:44.532  RESULT 1, 5, 3, 0.948698401, -0.122867517, -0.291390717, 0, 0.92144537, -0.388500631, 0.316234738, 0.36856994, 0.87417376  -  Edit
  11:18:44.532  CFRAME 3  -  Edit
  11:18:44.532  EXPECTED: 1, 6, 0, -0.316227823, 0.744208455, -0.588348389, -1.4901163e-08, 0.620173693, 0.784464538, 0.948683381, 0.248069525, -0.196116135  -  Edit
  11:18:44.532  RESULT 1, 6, 0, -0.3162328, 0.744193852, -0.588335812, 0, 0.620166659, 0.784478307, 0.948670208, 0.248077765, -0.196117043  -  Edit
  11:18:44.532  CFRAME 4  -  Edit
  11:18:44.532  EXPECTED: 1, -7, 9, 1, 0, -0, -0, 0.832050323, -0.554700196, -0, 0.554700196, 0.832050323  -  Edit
  11:18:44.532  RESULT 1, -7, 9, 1, 0, 0, 0, 0.832056642, -0.554704428, -0, 0.554704428, 0.832056642  -  Edit
  11:18:44.532  CFRAME 5  -  Edit
  11:18:44.533  EXPECTED: 1, 8, 4, -0, 0.948683262, -0.316227764, -0, 0.316227764, 0.948683262, 1, 0, -0  -  Edit
  11:18:44.533  RESULT 1, 8, 4, 0, 0.948698401, -0.3162328, 0, 0.3162328, 0.948698401, 1.00003183, -0, 0  -  Edit
```

if you find any major discrepency LMK

Also, this doesn't modify module.CFrameEuler. using the same techniques, its possible to get CFrameEuler to 18 bytes. 12 bytes from storing positions as f32 and the other 6 from storing rotations as i16s.