### PR TITLE
fix enum items

### DIFF
--- a/Decode.lua
+++ b/Decode.lua
@@ -317,8 +317,8 @@ local functions = {
 		return Vector3int16.new(X-32768,Y-32768,Z-32768),offset
 	end,
 	function(input: buffer, offset: number) -- EnumItem
-		local value = buru8(input, offset) 
-		offset += 1
+		local value = buru16(input, offset) 
+		offset += 2
 
 		local enumIdx = buru16(input, offset)
 		offset += 2

--- a/Encode.lua
+++ b/Encode.lua
@@ -288,9 +288,9 @@ functions = {
 		return buf
 	end,
 	function(v) -- EnumItem
-		local buf = bucr(3)
-		buwu8(buf, 0, v.Data[1]) -- value
-		buwu16(buf, 1, v.Data[2]) -- enum idx
+		local buf = bucr(4)
+		buwu16(buf, 0, v.Data[1]) -- value
+		buwu16(buf, 2, v.Data[2]) -- enum idx
 		return buf
 	end,
 	function(v) -- UDim2

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Example: `NetShrink.Nil()`
 <hr>
 
 ### EnumItem
-Stores an EnumItem as one 1-byte value and one 2-byte value.<br>
+Stores an EnumItem as one 2-byte value and one 2-byte value.<br>
 Arguments: `input: EnumItem`<br/>
 Example: `Netshrink.EnumItem(Enum.EasingDirection.Out)`
 <hr>


### PR DESCRIPTION
netshrink would trim long enum indexes, such as `Enum.KeyCode.Left` which has an index of 257

```lua
local netshrink = require(script.Parent:WaitForChild('NetShrink'))

local data = {
	Enum.KeyCode.Left;
	Enum.KeyCode.Left;
}

print(data)

local encoded = netshrink.Encode(data)

print('encoded', encoded)

local decoded = netshrink.Decode(encoded)

print('decoded', decoded)
```